### PR TITLE
store grow setup separate to grow name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 
-PUBLIC_FIREBASE_CONFIG='{
+FIREBASE_CONFIG='{
   "apiKey": "AIzaSyC495XCB6fD30B2svj7cAr",
   "authDomain": "your-firebase-domain.firebaseapp.com",
   "databaseURL": "https://your-firebase-domain-default-rtdb.asia-southeast1.firebasedatabase.app",
@@ -9,4 +9,4 @@ PUBLIC_FIREBASE_CONFIG='{
   "appId": "1:128390--999:web:47f64e3b"
 }'
 PORT=3003
-PUBLIC_API_URL=localhost:${PORT}
+API_URL=localhost:${PORT}

--- a/.github/workflows/end-to-end-tests-on-preview-app.yml
+++ b/.github/workflows/end-to-end-tests-on-preview-app.yml
@@ -21,9 +21,9 @@ jobs:
         with:
           command: npm run e2e-pipeline
           # quote the url to be safe against YML parsing surprises
-          wait-on: '${{ secrets.PUBLIC_UI_URL }}, ${{ secrets.PUBLIC_API_URL }}'
+          wait-on: '${{ secrets.UI_URL }}, ${{ secrets.API_URL }}'
         env:
-          CYPRESS_baseUrl: ${{ secrets.PUBLIC_UI_URL }}
+          CYPRESS_baseUrl: ${{ secrets.UI_URL }}
       - name: Test Recordings
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -24,9 +24,9 @@ jobs:
           start: npm start
           command: npm run e2e-pipeline
           # quote the url to be safe against YML parsing surprises
-          wait-on: '${{ secrets.PUBLIC_UI_URL }}, ${{ secrets.PUBLIC_API_URL }}'
+          wait-on: '${{ secrets.UI_URL }}, ${{ secrets.API_URL }}'
         env:
-          CYPRESS_baseUrl: ${{ secrets.PUBLIC_UI_URL }}
+          CYPRESS_baseUrl: ${{ secrets.UI_URL }}
       - name: Test Recordings
         uses: actions/upload-artifact@v4
         if: always()

--- a/api/src/services/database/firebase/index.ts
+++ b/api/src/services/database/firebase/index.ts
@@ -6,8 +6,7 @@ let app: App | undefined = undefined;
 if (!admin.apps.length) {
 	app = initializeApp({
 		credential: admin.credential.cert(JSON.parse(process.env.SECRET_FIREBASE_ADMIN_CREDENTIALS!)),
-		databaseURL: JSON.parse(process.env.PUBLIC_FIREBASE_CONFIG!).databaseURL
+		databaseURL: JSON.parse(process.env.FIREBASE_CONFIG!).databaseURL
 	});
 }
-
 export const database = getDatabase(app);

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,4 +1,4 @@
-PUBLIC_FIREBASE_CONFIG='{
+FIREBASE_CONFIG='{
   "apiKey": "AIzaSyC495XCB6fD30B2svj7cAr",
   "authDomain": "your-firebase-domain.firebaseapp.com",
   "databaseURL": "https://your-firebase-domain-default-rtdb.asia-southeast1.firebasedatabase.app",
@@ -8,4 +8,4 @@ PUBLIC_FIREBASE_CONFIG='{
   "appId": "1:128390--999:web:47f64e3b"
 }'
 PORT=3003
-PUBLIC_API_URL=localhost:${PORT}
+API_URL=localhost:${PORT}

--- a/app/src/features/grow-runs/grow-run/Actions.svelte
+++ b/app/src/features/grow-runs/grow-run/Actions.svelte
@@ -6,6 +6,7 @@
 	import GrowRun from '.';
 	import Modal from '$lib/components/Modal.svelte';
 	import UseResource from './resource-usages/AddAction.svelte';
+	import ChangeGrowSetup from './details/grow-setup/Action.svelte';
 	import ChangeLocation from './details/location/Action.svelte';
 	import RecordHarvest from './harvests/AddAction.svelte';
 	import MeasureEnvironmentalCondition from './conditions/MeasureEnvironmentalConditionAction.svelte';
@@ -25,6 +26,7 @@
 		growRunActionNames.start,
 		growRunActionNames.end,
 		growRunActionNames.changeLocation,
+		growRunActionNames.changeGrowSetup,
 		growRunActionNames.manageImages,
 
 		growRunActionNames.useResource,
@@ -97,6 +99,8 @@
 		<Modal onClose={closeModal}>
 			{#if openAction === growRunActionNames.rename}
 				<RenameAction {growRun} {closeModal} />
+			{:else if openAction === growRunActionNames.changeGrowSetup}
+				<ChangeGrowSetup {growRun} {closeModal} />
 			{:else if openAction === growRunActionNames.changeLocation}
 				<ChangeLocation {growRun} {closeModal} />
 			{:else if openAction === growRunActionNames.useResource}

--- a/app/src/features/grow-runs/grow-run/Preview.svelte
+++ b/app/src/features/grow-runs/grow-run/Preview.svelte
@@ -2,15 +2,20 @@
 	import { resourcesList } from '$features/resources/store';
 	import type GrowRun from '$features/grow-runs/grow-run';
 	import Icon from '@iconify/svelte';
+	import { growSetups } from '$features/grow-setups/store';
 	export let growRun: GrowRun;
 
 	$: cost = growRun.calculateCost($resourcesList);
 	$: costPer100g = growRun.calculateCostPer100g($resourcesList);
+	$: growRunGrowSetup = growRun.growSetup && $growSetups.find((gs) => gs.id === growRun.growSetup);
 </script>
 
 <tr>
 	<td>
 		<a href="/grow-runs/{growRun.id}" style="width: 100%">
+			{#if growRunGrowSetup}
+				<p class="inline-flex">({growRunGrowSetup.shortName})</p>
+			{/if}
 			{#if growRun.location?.address.city}
 				<p class="inline-flex">
 					(<Icon icon="tabler:map-pin" class="mr-1" />{growRun.location.address.city})

--- a/app/src/features/grow-runs/grow-run/details/View.svelte
+++ b/app/src/features/grow-runs/grow-run/details/View.svelte
@@ -1,19 +1,18 @@
 <script lang="ts">
-	import GrowRun from '..';
-
-	export let growRun: GrowRun;
-
+	import GrowSetup from './grow-setup/View.svelte';
 	import Location from './location/View.svelte';
 	import Duration from './duration/View.svelte';
 	import Photos from './photos/View.svelte';
+	import GrowRun from '..';
+
+	export let growRun: GrowRun;
 </script>
 
 <div class="flex-1 w-[90%]">
 	<h2>{growRun.name}</h2>
 
+	<GrowSetup {growRun} />
 	<Location {growRun} />
-
 	<Duration {growRun} />
-
 	<Photos {growRun} />
 </div>

--- a/app/src/features/grow-runs/grow-run/details/grow-setup/Action.svelte
+++ b/app/src/features/grow-runs/grow-run/details/grow-setup/Action.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type GrowRun from '$features/grow-runs/grow-run';
+	import { growRunsAPI } from '$features/grow-runs/grow-run/store';
+	import ActionTemplate from '$lib/components/ActionTemplate.svelte';
+	import { growRunActionNames } from '@grow-run-archive/definitions';
+	import Inputs from './Inputs.svelte';
+
+	export let growRun: GrowRun;
+	export let closeModal: () => any;
+
+	let updatedGrowSetup: GrowRun['growSetup'] = growRun.growSetup;
+</script>
+
+<ActionTemplate
+	actionName={growRunActionNames.changeGrowSetup}
+	onComplete={() => growRunsAPI.updatePartial(growRun.id, { growSetup: updatedGrowSetup })}
+	onCancel={closeModal}
+>
+	<Inputs bind:updatedGrowSetup />
+</ActionTemplate>

--- a/app/src/features/grow-runs/grow-run/details/grow-setup/Inputs.svelte
+++ b/app/src/features/grow-runs/grow-run/details/grow-setup/Inputs.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { growSetups } from '$features/grow-setups/store';
+	import { type GrowSetupType } from '@grow-run-archive/definitions';
+	export let updatedGrowSetup: GrowSetupType['id'] | undefined;
+</script>
+
+<select bind:value={updatedGrowSetup}>
+	{#each $growSetups as growSetup (growSetup.id)}
+		<option value={growSetup.id}>{growSetup.name}</option>
+	{/each}
+</select>

--- a/app/src/features/grow-runs/grow-run/details/grow-setup/View.svelte
+++ b/app/src/features/grow-runs/grow-run/details/grow-setup/View.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import type GrowRun from '$features/grow-runs/grow-run';
+	import { growSetups } from '$features/grow-setups/store';
+
+	export let growRun: GrowRun;
+
+	$: growSetup = $growSetups.find((randomGrowSetup) => randomGrowSetup.id === growRun.growSetup);
+</script>
+
+{#if growSetup}
+	<a href="/grow-setups/{growSetup.id}">{growSetup.name}</a>
+{/if}

--- a/app/src/features/grow-runs/grow-run/details/location/Action.svelte
+++ b/app/src/features/grow-runs/grow-run/details/location/Action.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { PUBLIC_API_URL } from '$env/static/public';
+	import { API_URL } from '$env/static/public';
 	import type GrowRun from '$features/grow-runs/grow-run';
 	import { growRunsAPI } from '$features/grow-runs/grow-run/store';
 	import ActionTemplate from '$lib/components/ActionTemplate.svelte';
@@ -38,7 +38,7 @@
 		lastCoords = { ...coordinates };
 
 		const geocodeResult = await (
-			await fetch(`${PUBLIC_API_URL}/grow-run/location`, {
+			await fetch(`${API_URL}/grow-run/location`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({ coords: coordinates })

--- a/app/src/features/grow-runs/grow-run/details/location/Inputs.svelte
+++ b/app/src/features/grow-runs/grow-run/details/location/Inputs.svelte
@@ -11,8 +11,10 @@
 		if ('geolocation' in navigator) {
 			/* geolocation is available */
 			navigator.geolocation.getCurrentPosition(
-				(position) => (updatedGrowRunCoords = position.coords),
-				(e) => console.log('something has gone wrong :(', e)
+				({ coords }) =>
+					(updatedGrowRunCoords = { latitude: coords.latitude, longitude: coords.longitude }),
+				(e) => console.log('something has gone wrong :(', e),
+				{ enableHighAccuracy: true }
 			);
 		} else {
 			/* geolocation IS NOT available */

--- a/app/src/features/grow-runs/grow-run/harvests/View.svelte
+++ b/app/src/features/grow-runs/grow-run/harvests/View.svelte
@@ -28,7 +28,7 @@
 			</li>
 		</ul>
 	{:else}
-		<p class="inline">No harvests recorded</p>
+		<p>No harvests recorded</p>
 	{/if}
 </section>
 

--- a/app/src/features/grow-runs/grow-run/resource-usages/View.svelte
+++ b/app/src/features/grow-runs/grow-run/resource-usages/View.svelte
@@ -30,7 +30,7 @@
 			</li>
 		</ul>
 	{:else}
-		<p class="inline">No resources used</p>
+		<p>No resources used</p>
 	{/if}
 
 	{#if growRun.resources?.used?.length}

--- a/app/src/features/grow-setups/Actions.svelte
+++ b/app/src/features/grow-setups/Actions.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { growRunActionNames } from '@grow-run-archive/definitions';
+	import AddAction from './AddAction.svelte';
+	import ActionsMenuModal from '$lib/components/ActionsMenuModal.svelte';
+	import Icon from '@iconify/svelte';
+
+	let showActionsMenu = false;
+
+	let actions = [growRunActionNames.add];
+</script>
+
+<div class="group m-4 relative">
+	<button title="Actions for Grow Runs" on:click={() => (showActionsMenu = !showActionsMenu)}>
+		<Icon icon="tabler:dots" />
+	</button>
+	<ActionsMenuModal bind:showActionsMenu {actions} let:filteredActions>
+		<AddAction closeModal={() => (showActionsMenu = false)} />
+	</ActionsMenuModal>
+</div>

--- a/app/src/features/grow-setups/AddAction.svelte
+++ b/app/src/features/grow-setups/AddAction.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { growSetupActionNames, type GrowSetupType } from '@grow-run-archive/definitions';
+	import ActionTemplate from '../../lib/components/ActionTemplate.svelte';
+	import { growSetupsAPI, growSetups } from './store';
+
+	export let closeModal: () => any;
+
+	let nicknameInput = '';
+	let linkInput = '';
+	let previousVersion: GrowSetupType['version'] | null = $growSetups.length
+		? $growSetups.sort().at(-1)!.version
+		: null;
+
+	$: version = calculateNextVersion(previousVersion);
+
+	function calculateNextVersion(previousVersion: GrowSetupType['version'] | null) {
+		if (!previousVersion) {
+			if (!$growSetups.length) return '1';
+
+			previousVersion = $growSetups.sort().at(-1)!.version;
+		}
+
+		const versionComponents = previousVersion.split('.');
+
+		versionComponents[versionComponents.length - 1] = (
+			parseInt(versionComponents.at(-1)!) + 1
+		).toString();
+
+		return versionComponents.join('.');
+	}
+</script>
+
+<ActionTemplate
+	actionName={growSetupActionNames.add}
+	onCancel={closeModal}
+	onComplete={() => growSetupsAPI.add({ nickname: nicknameInput, link: linkInput, version })}
+>
+	{#if previousVersion}
+		<div class="horizontal-input-group">
+			<label for="version-input">Previous version</label>
+			<select bind:value={previousVersion}>
+				{#each $growSetups as growSetup (growSetup.id)}
+					<option value={growSetup.version}>{growSetup.name}</option>
+				{/each}
+				<option value="No previous version">None</option>
+			</select>
+		</div>
+	{/if}
+	<input type="text" placeholder="grow setup nickname" bind:value={nicknameInput} />
+	<input type="text" placeholder="grow setup link" bind:value={linkInput} />
+</ActionTemplate>

--- a/app/src/features/grow-setups/AddAction.svelte
+++ b/app/src/features/grow-setups/AddAction.svelte
@@ -2,58 +2,25 @@
 	import { growSetupActionNames, type GrowSetupType } from '@grow-run-archive/definitions';
 	import ActionTemplate from '../../lib/components/ActionTemplate.svelte';
 	import { growSetupsAPI, growSetups } from './store';
+	import Inputs from './grow-setup/Inputs.svelte';
 
 	export let closeModal: () => any;
 
-	let nicknameInput: string | undefined;
-	let linkInput: string | undefined;
-	let previousVersion: GrowSetupType['version'] | null = null;
+	let nickname: string | undefined;
+	let link: string | undefined;
+	let version: string;
 
-	$: version = calculateNextVersion(previousVersion);
-
-	function calculateNextVersion(previousVersion: GrowSetupType['version'] | null) {
-		if (!previousVersion) {
-			if (!$growSetups.length) return '1';
-
-			previousVersion = $growSetups
-				.sort((a, b) => a.version.localeCompare(b.version))
-				.at(-1)!.version;
-		} else {
-			if (!previousVersion.includes('.')) previousVersion += '.0';
-		}
-
-		const versionComponents = previousVersion.split('.');
-
-		versionComponents[versionComponents.length - 1] = (
-			parseInt(versionComponents.at(-1)!) + 1
-		).toString();
-
-		return versionComponents.join('.');
+	function addAndReset() {
+		growSetupsAPI.add({ nickname, link, version });
+		link = undefined;
+		nickname = undefined;
 	}
 </script>
 
 <ActionTemplate
 	actionName={growSetupActionNames.add}
 	onCancel={closeModal}
-	onComplete={() => growSetupsAPI.add({ nickname: nicknameInput, link: linkInput, version })}
+	onComplete={addAndReset}
 >
-	{#if $growSetups.length}
-		<div class="horizontal-input-group">
-			<label for="version-input">Related grow setup</label>
-			<select bind:value={previousVersion}>
-				{#each $growSetups as growSetup (growSetup.id)}
-					<option value={growSetup.version}>{growSetup.name}</option>
-				{/each}
-				<option value={null}>None</option>
-			</select>
-		</div>
-	{/if}
-	<p>Version #{version}</p>
-	<label class="horizontal-input-group">
-		Nickname <input type="text" placeholder="grow setup nickname" bind:value={nicknameInput} />
-	</label>
-	<label class="horizontal-input-group">
-		Link
-		<input type="text" placeholder="grow setup link" bind:value={linkInput} />
-	</label>
+	<Inputs bind:version bind:nickname bind:link />
 </ActionTemplate>

--- a/app/src/features/grow-setups/AddAction.svelte
+++ b/app/src/features/grow-setups/AddAction.svelte
@@ -5,11 +5,9 @@
 
 	export let closeModal: () => any;
 
-	let nicknameInput = '';
-	let linkInput = '';
-	let previousVersion: GrowSetupType['version'] | null = $growSetups.length
-		? $growSetups.sort().at(-1)!.version
-		: null;
+	let nicknameInput: string | undefined;
+	let linkInput: string | undefined;
+	let previousVersion: GrowSetupType['version'] | null = null;
 
 	$: version = calculateNextVersion(previousVersion);
 
@@ -17,7 +15,11 @@
 		if (!previousVersion) {
 			if (!$growSetups.length) return '1';
 
-			previousVersion = $growSetups.sort().at(-1)!.version;
+			previousVersion = $growSetups
+				.sort((a, b) => a.version.localeCompare(b.version))
+				.at(-1)!.version;
+		} else {
+			if (!previousVersion.includes('.')) previousVersion += '.0';
 		}
 
 		const versionComponents = previousVersion.split('.');
@@ -35,17 +37,23 @@
 	onCancel={closeModal}
 	onComplete={() => growSetupsAPI.add({ nickname: nicknameInput, link: linkInput, version })}
 >
-	{#if previousVersion}
+	{#if $growSetups.length}
 		<div class="horizontal-input-group">
-			<label for="version-input">Previous version</label>
+			<label for="version-input">Related grow setup</label>
 			<select bind:value={previousVersion}>
 				{#each $growSetups as growSetup (growSetup.id)}
 					<option value={growSetup.version}>{growSetup.name}</option>
 				{/each}
-				<option value="No previous version">None</option>
+				<option value={null}>None</option>
 			</select>
 		</div>
 	{/if}
-	<input type="text" placeholder="grow setup nickname" bind:value={nicknameInput} />
-	<input type="text" placeholder="grow setup link" bind:value={linkInput} />
+	<p>Version #{version}</p>
+	<label class="horizontal-input-group">
+		Nickname <input type="text" placeholder="grow setup nickname" bind:value={nicknameInput} />
+	</label>
+	<label class="horizontal-input-group">
+		Link
+		<input type="text" placeholder="grow setup link" bind:value={linkInput} />
+	</label>
 </ActionTemplate>

--- a/app/src/features/grow-setups/View.svelte
+++ b/app/src/features/grow-setups/View.svelte
@@ -8,3 +8,9 @@
 		<GrowSetup {growSetup} />
 	{/each}
 </ul>
+
+<style lang="postcss">
+	ul {
+		@apply flex flex-col gap-4;
+	}
+</style>

--- a/app/src/features/grow-setups/View.svelte
+++ b/app/src/features/grow-setups/View.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import GrowSetup from '$features/grow-setups/grow-setup/Preview.svelte';
+	import { growSetups } from '$features/grow-setups/store';
+</script>
+
+<ul>
+	{#each $growSetups as growSetup}
+		<GrowSetup {growSetup} />
+	{/each}
+</ul>

--- a/app/src/features/grow-setups/View.svelte
+++ b/app/src/features/grow-setups/View.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
-	import GrowSetup from '$features/grow-setups/grow-setup/Preview.svelte';
+	import GrowSetup1 from '$features/grow-setups/grow-setup/Preview.svelte';
 	import { growSetups } from '$features/grow-setups/store';
+	import { GrowSetup } from '@grow-run-archive/definitions';
+
+	$: sortedGrowSetups = GrowSetup.sort($growSetups);
 </script>
 
 <ul>
-	{#each $growSetups as growSetup}
-		<GrowSetup {growSetup} />
+	{#each sortedGrowSetups as growSetup}
+		<GrowSetup1 {growSetup} />
 	{/each}
 </ul>
 

--- a/app/src/features/grow-setups/grow-setup/Actions.svelte
+++ b/app/src/features/grow-setups/grow-setup/Actions.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import EditButton from '$lib/components/EditButton.svelte';
+	import { GrowSetup, growSetupActionNames } from '@grow-run-archive/definitions';
+	import EditAction from './EditAction.svelte';
+	import Modal from '$lib/components/Modal.svelte';
+
+	export let growSetup: GrowSetup;
+	let showActionsMenu = false;
+</script>
+
+<div class="group m-4 relative">
+	<button
+		title={growSetupActionNames.openActions}
+		on:click={() => (showActionsMenu = !showActionsMenu)}
+	>
+		<EditButton />
+	</button>
+	<Modal onClose={() => (showActionsMenu = false)}>
+		<EditAction closeModal={() => null} {growSetup} />
+	</Modal>
+</div>

--- a/app/src/features/grow-setups/grow-setup/EditAction.svelte
+++ b/app/src/features/grow-setups/grow-setup/EditAction.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { GrowSetup, growSetupActionNames } from '@grow-run-archive/definitions';
+	import ActionTemplate from '$lib/components/ActionTemplate.svelte';
+	import { growSetupsAPI } from '../store';
+	import Inputs from './Inputs.svelte';
+
+	export let growSetup: GrowSetup;
+	export let closeModal: () => any;
+
+	let nickname = growSetup.nickname;
+	let link = growSetup.link;
+	let version = growSetup.version;
+</script>
+
+<ActionTemplate
+	actionName={growSetupActionNames.edit}
+	onCancel={closeModal}
+	onComplete={() => growSetupsAPI.updateFull({ id: growSetup.id, nickname, link, version })}
+>
+	<Inputs bind:version bind:nickname bind:link />
+</ActionTemplate>

--- a/app/src/features/grow-setups/grow-setup/Inputs.svelte
+++ b/app/src/features/grow-setups/grow-setup/Inputs.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import { GrowSetup, type GrowSetupType } from '@grow-run-archive/definitions';
+	import { growSetups } from '../store';
+
+	let previousVersion: GrowSetupType['version'] | null | undefined = null;
+	export let nickname: string | undefined;
+	export let link: string | undefined;
+	export let version: GrowSetupType['version'];
+
+	$: version = calculateNextVersion(previousVersion);
+	$: if ($growSetups.find((gs) => gs.version === version)) {
+		version = calculateNextVersion(previousVersion);
+	}
+
+	function calculateNextVersion(previousVersion: GrowSetupType['version'] | null | undefined) {
+		if (previousVersion === undefined && version) return version;
+
+		if (!previousVersion) {
+			if (!$growSetups.length) return '1';
+
+			previousVersion = GrowSetup.sort($growSetups).at(-1)!.version;
+		} else {
+			if (!previousVersion.includes('.')) previousVersion += '.0';
+		}
+
+		const versionComponents = previousVersion.split('.');
+
+		versionComponents[versionComponents.length - 1] = (
+			parseInt(versionComponents.at(-1)!) + 1
+		).toString();
+
+		return versionComponents.join('.');
+	}
+</script>
+
+{#if $growSetups.length}
+	<div class="horizontal-input-group">
+		<label for="version-input">Related grow setup</label>
+		<select bind:value={previousVersion}>
+			{#each $growSetups as growSetup (growSetup.id)}
+				<option value={growSetup.version}>{growSetup.name}</option>
+			{/each}
+			<option value={null}>None</option>
+		</select>
+	</div>
+{/if}
+<p>Version #{version}</p>
+<label class="horizontal-input-group">
+	Nickname <input type="text" placeholder="grow setup nickname" bind:value={nickname} />
+</label>
+<label class="horizontal-input-group">
+	Link
+	<input type="text" placeholder="grow setup link" bind:value={link} />
+</label>

--- a/app/src/features/grow-setups/grow-setup/Preview.svelte
+++ b/app/src/features/grow-setups/grow-setup/Preview.svelte
@@ -8,10 +8,12 @@
 	<a href="/grow-setups/{growSetup.id}" class="flex-1">
 		{growSetup.name}
 	</a>
-	<a href={growSetup.link} target="_blank" class="flex items-center bg-green-500">
-		<span>Full Design</span>
-		<Icon icon="tabler:external-link" />
-	</a>
+	{#if growSetup.link}
+		<a href={growSetup.link} target="_blank" class="flex items-center bg-green-500">
+			<span>Full Design</span>
+			<Icon icon="tabler:external-link" />
+		</a>
+	{/if}
 </li>
 
 <style lang="postcss">

--- a/app/src/features/grow-setups/grow-setup/Preview.svelte
+++ b/app/src/features/grow-setups/grow-setup/Preview.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import type { GrowSetup } from '@grow-run-archive/definitions';
+	import Icon from '@iconify/svelte';
+	export let growSetup: GrowSetup;
+</script>
+
+<li>
+	<a href="/grow-setups/{growSetup.id}" class="flex-1">
+		{growSetup.name}
+	</a>
+	<a href={growSetup.link} target="_blank" class="flex items-center bg-green-500">
+		<span>Full Design</span>
+		<Icon icon="tabler:external-link" />
+	</a>
+</li>
+
+<style lang="postcss">
+	li {
+		border-radius: var(--brad);
+		@apply flex items-center overflow-hidden justify-between bg-[lightblue];
+	}
+
+	a {
+		@apply p-4;
+	}
+</style>

--- a/app/src/features/grow-setups/grow-setup/Preview.svelte
+++ b/app/src/features/grow-setups/grow-setup/Preview.svelte
@@ -9,7 +9,7 @@
 		{growSetup.name}
 	</a>
 	{#if growSetup.link}
-		<a href={growSetup.link} target="_blank" class="flex items-center bg-green-500">
+		<a href={growSetup.link} target="_blank" class="flex gap-2 items-center bg-green-500">
 			<span>Full Design</span>
 			<Icon icon="tabler:external-link" />
 		</a>

--- a/app/src/features/grow-setups/grow-setup/View.svelte
+++ b/app/src/features/grow-setups/grow-setup/View.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { growRuns } from '$features/grow-runs/grow-run/store';
+	import type { GrowSetup } from '@grow-run-archive/definitions';
+	import GrowRun from '$features/grow-runs/grow-run/Preview.svelte';
+	import Icon from '@iconify/svelte';
+
+	export let growSetup: GrowSetup;
+	$: growRunsWithThisSetup = $growRuns.filter((growRun) => growRun.growSetup === growSetup.id);
+</script>
+
+<h1>
+	<a href={growSetup.link} target="_blank">
+		{growSetup.name}
+		<Icon icon="tabler:external-link" />
+	</a>
+</h1>
+<table>
+	<thead>
+		<tr>
+			<th>Name</th>
+			<th>Output (g)</th>
+			<th>Cost (NZD)</th>
+			<th>Cost per 100g (NZD)</th>
+		</tr>
+	</thead>
+
+	<tbody>
+		{#each growRunsWithThisSetup as growRun}
+			<GrowRun {growRun} />
+		{/each}
+	</tbody>
+</table>

--- a/app/src/features/grow-setups/grow-setup/View.svelte
+++ b/app/src/features/grow-setups/grow-setup/View.svelte
@@ -9,24 +9,34 @@
 </script>
 
 <h1>
-	<a href={growSetup.link} target="_blank">
+	{#if growSetup.link}
+		<a href={growSetup.link} target="_blank">
+			{growSetup.name}
+			<Icon icon="tabler:external-link" />
+		</a>
+	{:else}
 		{growSetup.name}
-		<Icon icon="tabler:external-link" />
-	</a>
+	{/if}
 </h1>
-<table>
-	<thead>
-		<tr>
-			<th>Name</th>
-			<th>Output (g)</th>
-			<th>Cost (NZD)</th>
-			<th>Cost per 100g (NZD)</th>
-		</tr>
-	</thead>
 
-	<tbody>
-		{#each growRunsWithThisSetup as growRun}
-			<GrowRun {growRun} />
-		{/each}
-	</tbody>
-</table>
+{#if growRunsWithThisSetup.length}
+	<h2>Grow runs using setup</h2>
+	<table>
+		<thead>
+			<tr>
+				<th>Name</th>
+				<th>Output (g)</th>
+				<th>Cost (NZD)</th>
+				<th>Cost per 100g (NZD)</th>
+			</tr>
+		</thead>
+
+		<tbody>
+			{#each growRunsWithThisSetup as growRun}
+				<GrowRun {growRun} />
+			{/each}
+		</tbody>
+	</table>
+{:else}
+	<p>No grow runs using this setup</p>
+{/if}

--- a/app/src/features/grow-setups/grow-setup/View.svelte
+++ b/app/src/features/grow-setups/grow-setup/View.svelte
@@ -3,21 +3,25 @@
 	import type { GrowSetup } from '@grow-run-archive/definitions';
 	import GrowRun from '$features/grow-runs/grow-run/Preview.svelte';
 	import Icon from '@iconify/svelte';
+	import EditAction from './Actions.svelte';
 
 	export let growSetup: GrowSetup;
 	$: growRunsWithThisSetup = $growRuns.filter((growRun) => growRun.growSetup === growSetup.id);
 </script>
 
-<h1>
-	{#if growSetup.link}
-		<a href={growSetup.link} target="_blank">
+<div class="flex justify-between items-center">
+	<h1>
+		{#if growSetup.link}
+			<a href={growSetup.link} target="_blank">
+				{growSetup.name}
+				<Icon icon="tabler:external-link" />
+			</a>
+		{:else}
 			{growSetup.name}
-			<Icon icon="tabler:external-link" />
-		</a>
-	{:else}
-		{growSetup.name}
-	{/if}
-</h1>
+		{/if}
+	</h1>
+	<EditAction {growSetup} />
+</div>
 
 {#if growRunsWithThisSetup.length}
 	<h2>Grow runs using setup</h2>

--- a/app/src/features/grow-setups/store.ts
+++ b/app/src/features/grow-setups/store.ts
@@ -1,0 +1,9 @@
+import { EntityAPI } from '$lib/entity/api';
+import { createEntityStores } from '$lib/entity/store';
+import { GrowSetup, type GrowSetupType } from '@grow-run-archive/definitions';
+
+export const growSetupsAPI = new EntityAPI<GrowSetupType>('grow-setups', 'id');
+export const { loading: growSetupsLoading, records: growSetups } = createEntityStores(
+	GrowSetup,
+	growSetupsAPI
+);

--- a/app/src/features/resources/Actions.svelte
+++ b/app/src/features/resources/Actions.svelte
@@ -8,7 +8,10 @@
 </script>
 
 <div class="group m-4 relative">
-	<button title="Actions for Resources" on:click={() => (showActionsMenu = !showActionsMenu)}>
+	<button
+		title={resourceActionNames.openActions}
+		on:click={() => (showActionsMenu = !showActionsMenu)}
+	>
 		<Icon icon="tabler:dots" />
 	</button>
 	<ActionsMenuModal bind:showActionsMenu actions={[resourceActionNames.add]}>

--- a/app/src/features/resources/resource/View.svelte
+++ b/app/src/features/resources/resource/View.svelte
@@ -7,6 +7,7 @@
 	import ActionTemplate from '$lib/components/ActionTemplate.svelte';
 	import Icon from '@iconify/svelte';
 	import ConfirmActionModal from '$lib/components/ConfirmActionModal.svelte';
+	import EditButton from '$lib/components/EditButton.svelte';
 
 	export let resource: Resource;
 
@@ -22,8 +23,8 @@
 {#if expanded}
 	<tr>
 		<td colspan="10">
-			<button on:click={() => (editing = !editing)} title="Edit resource">
-				<Icon icon="tabler:pencil" />
+			<button on:click={() => (editing = !editing)} title={resourceActionNames.edit}>
+				<EditButton />
 			</button>
 			{#if editing}
 				<ActionTemplate

--- a/app/src/features/user/auth.ts
+++ b/app/src/features/user/auth.ts
@@ -2,7 +2,7 @@ import { connectAuthEmulator, getAuth, type Auth } from 'firebase/auth';
 import { derived } from 'svelte/store';
 import { app } from '$lib/firebase';
 import { session } from './session';
-import { env } from '$lib/env';
+import { env } from '$env/dynamic/public';
 
 export const auth = derived<typeof app, Auth | undefined>(app, (app, setAuth) => {
 	if (!app) {

--- a/app/src/features/user/auth.ts
+++ b/app/src/features/user/auth.ts
@@ -13,7 +13,11 @@ export const auth = derived<typeof app, Auth | undefined>(app, (app, setAuth) =>
 
 	if (env.ENV === 'test' && env.FIREBASE_AUTH_EMULATOR_HOST) {
 		const authEmulatorUrl = `http://${env.FIREBASE_AUTH_EMULATOR_HOST}`;
-		connectAuthEmulator(auth, authEmulatorUrl);
+		try {
+			connectAuthEmulator(auth, authEmulatorUrl);
+		} catch (e) {
+			console.error(e);
+		}
 	}
 
 	setAuth(auth);

--- a/app/src/lib/components/AuthMenu.svelte
+++ b/app/src/lib/components/AuthMenu.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import Icon from '@iconify/svelte';
+	import MenuDropDown from './MenuDropDown.svelte';
+	import { session } from '$features/user/session';
+	import { userActionNames } from '@grow-run-archive/definitions';
+</script>
+
+<nav>
+	<MenuDropDown>
+		<p class="nav-item" slot="text" title={userActionNames.openMenu}>
+			<Icon icon="tabler:user-circle" />
+		</p>
+		<p class="hidden md:block">
+			Logged in as
+			<span class="font-bold">{$session.user?.email}</span>
+		</p>
+		<a href="/settings" class="flex gap-2 items-center">
+			<Icon icon="tabler:settings" /> Settings
+		</a>
+		<a href="/logout">Logout</a>
+	</MenuDropDown>
+</nav>

--- a/app/src/lib/components/ConfirmActionModal.svelte
+++ b/app/src/lib/components/ConfirmActionModal.svelte
@@ -21,7 +21,7 @@
 
 {#if askForConfirmation}
 	<Modal onClose={() => (askForConfirmation = false)}>
-		<p>Are you sure?</p>
+		<h3>Are you sure?</h3>
 		<button
 			title="Confirm Action"
 			on:click={() => {

--- a/app/src/lib/components/EditButton.svelte
+++ b/app/src/lib/components/EditButton.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import Icon from '@iconify/svelte';
+</script>
+
+<Icon icon="tabler:pencil" />

--- a/app/src/lib/components/Loading.svelte
+++ b/app/src/lib/components/Loading.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { env } from '$lib/env';
+	import { env } from '$env/dynamic/public';
+
 	export let loading;
 
 	// a fixed loading time so animation can be enjoyed :)

--- a/app/src/lib/components/Menu.svelte
+++ b/app/src/lib/components/Menu.svelte
@@ -5,6 +5,7 @@
 <nav class="flex gap-[15px] items-start">
 	<a href="/grow-runs">Grow Runs</a>
 	<a href="/resources">Resources</a>
+	<a href="/grow-setups">Grow Setups</a>
 	<MenuDropDown>
 		<p slot="text" class="nav-item">Cost</p>
 		<a href="/cost/graph">Graph</a>

--- a/app/src/lib/components/Menu.svelte
+++ b/app/src/lib/components/Menu.svelte
@@ -6,7 +6,7 @@
 	<a href="/grow-runs">Grow Runs</a>
 	<a href="/resources">Resources</a>
 	<MenuDropDown>
-		<p slot="text">Cost</p>
+		<p slot="text" class="nav-item">Cost</p>
 		<a href="/cost/graph">Graph</a>
 		<a href="/cost/pie-charts">Pies 🥧📊</a>
 	</MenuDropDown>

--- a/app/src/lib/components/MenuDropDown.svelte
+++ b/app/src/lib/components/MenuDropDown.svelte
@@ -1,8 +1,19 @@
-<div class="group">
+<script lang="ts">
+	let dropdownmenu: HTMLDivElement | undefined;
+	let rightHandSide = false;
+
+	// if the sub menu is overflowing the page, move it across
+	$: if (dropdownmenu && dropdownmenu.getBoundingClientRect().right + 100 > window.innerWidth) {
+		rightHandSide = true;
+	}
+</script>
+
+<div class="group relative" bind:this={dropdownmenu}>
 	<slot name="text" />
 
 	<div
-		class="hidden flex-col p-4 rounded-md absolute gap-1 group-hover:flex h-0 group-hover:h-fit overflow-hidden transition-[height] duration-1000 ease-out bg-gray-800 bg-opacity-65"
+		class="hidden -z-10 flex-col p-4 pt-[3rem] w-max rounded-md absolute gap-1 group-hover:flex items-start h-0 top-0 group-hover:h-fit overflow-hidden transition-[height] duration-1000 ease-out bg-gray-800 bg-opacity-65
+		{rightHandSide ? 'right-0 items-end' : ''}"
 	>
 		<slot />
 	</div>

--- a/app/src/lib/components/Modal.svelte
+++ b/app/src/lib/components/Modal.svelte
@@ -6,7 +6,10 @@
 	$: if (modal) modal.showModal();
 </script>
 
-<svelte:body
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+<dialog
+	bind:this={modal}
 	on:click|capture={({ detail, clientX, clientY }) => {
 		if (detail === 0) return; // don't close modal for non-mouse click events
 		if (!modal) return;
@@ -14,10 +17,6 @@
 
 		if (clientX < left || right < clientX || clientY < top || bottom < clientY) modal?.close();
 	}}
-/>
-
-<dialog
-	bind:this={modal}
 	on:close={onClose}
 	class="p-0 m-auto border-none rounded-xl drop-shadow-md max-h-[90vh] md:max-w-[75%]"
 >

--- a/app/src/lib/database/index.ts
+++ b/app/src/lib/database/index.ts
@@ -1,7 +1,7 @@
 import { derived } from 'svelte/store';
 import { connectDatabaseEmulator, Database, getDatabase } from 'firebase/database';
 import { app } from '$lib/firebase';
-import { env } from '$lib/env';
+import { env } from '$env/dynamic/public';
 
 export const db = derived<typeof app, Database | undefined>(app, (app, setDb) => {
 	if (!app) return setDb(undefined);

--- a/app/src/lib/database/index.ts
+++ b/app/src/lib/database/index.ts
@@ -10,7 +10,11 @@ export const db = derived<typeof app, Database | undefined>(app, (app, setDb) =>
 
 	if (env.ENV === 'test' && env.FIREBASE_DATABASE_EMULATOR_HOST) {
 		const [host, port] = env.FIREBASE_DATABASE_EMULATOR_HOST.split(':');
-		connectDatabaseEmulator(database, host, parseInt(port));
+		try {
+			connectDatabaseEmulator(database, host, parseInt(port));
+		} catch (e) {
+			console.info(e);
+		}
 	}
 
 	setDb(database);

--- a/app/src/lib/entity/api.ts
+++ b/app/src/lib/entity/api.ts
@@ -38,6 +38,10 @@ export class EntityAPI<Entity> {
 		const recordsRef = this.entityRef();
 		if (!recordsRef) return;
 
+		Object.keys(entityAdd).forEach((key) => {
+			entityAdd[key as keyof Entity] === undefined && delete entityAdd[key as keyof Entity];
+		});
+
 		const newRecordRef = firebase.push(recordsRef);
 		firebase.set(newRecordRef, entityAdd);
 	}

--- a/app/src/lib/entity/api.ts
+++ b/app/src/lib/entity/api.ts
@@ -3,6 +3,14 @@ import { session } from '$features/user/session';
 import * as firebase from 'firebase/database';
 import { get } from 'svelte/store';
 
+function deleteUndefinedProperties(obj: any) {
+	Object.keys(obj).forEach((key) => {
+		obj[key] === undefined && delete obj[key];
+	});
+
+	return obj;
+}
+
 /**
  * This API can be used to interact with an entity which is stored within an Array on the firebase database
  */
@@ -26,24 +34,20 @@ export class EntityAPI<Entity> {
 
 	updateFull(entity: Entity) {
 		const entityRef = this.entityRef(`/${entity[this.entityIdProperty]}`);
-		entityRef && firebase.set(entityRef, entity);
+		entityRef && firebase.set(entityRef, deleteUndefinedProperties(entity));
 	}
 
 	updatePartial(entityId: string, entityUpdates: Partial<Entity>) {
 		const entityRef = this.entityRef(`/${entityId}`);
-		entityRef && firebase.update(entityRef, entityUpdates);
+		entityRef && firebase.update(entityRef, deleteUndefinedProperties(entityUpdates));
 	}
 
 	add(entityAdd: Partial<Entity>) {
 		const recordsRef = this.entityRef();
 		if (!recordsRef) return;
 
-		Object.keys(entityAdd).forEach((key) => {
-			entityAdd[key as keyof Entity] === undefined && delete entityAdd[key as keyof Entity];
-		});
-
 		const newRecordRef = firebase.push(recordsRef);
-		firebase.set(newRecordRef, entityAdd);
+		firebase.set(newRecordRef, deleteUndefinedProperties(entityAdd));
 	}
 
 	delete(id: string) {

--- a/app/src/lib/env/index.ts
+++ b/app/src/lib/env/index.ts
@@ -1,1 +1,0 @@
-export const env = import.meta.env;

--- a/app/src/lib/firebase/index.ts
+++ b/app/src/lib/firebase/index.ts
@@ -1,5 +1,5 @@
-import { PUBLIC_FIREBASE_CONFIG } from '$env/static/public';
-const firebaseConfig = JSON.parse(PUBLIC_FIREBASE_CONFIG);
+import { FIREBASE_CONFIG } from '$env/static/public';
+const firebaseConfig = JSON.parse(FIREBASE_CONFIG);
 
 import { initializeApp, type FirebaseApp } from 'firebase/app';
 import { browser } from '$app/environment';

--- a/app/src/lib/styles/global.css
+++ b/app/src/lib/styles/global.css
@@ -5,6 +5,7 @@
 *,
 body {
 	box-sizing: border-box;
+	--brad: 10px;
 	@apply m-0 p-0;
 }
 
@@ -49,12 +50,10 @@ button {
 
 button,
 nav a,
-nav p,
 .nav-item {
 	outline: none;
 	border: none;
 	background-color: rgb(199, 230, 173);
-	cursor: pointer;
 	padding: 5px;
 	border-radius: 8px;
 	text-decoration: none;
@@ -141,14 +140,14 @@ tbody td {
 
 tbody td:first-of-type {
 	border: 1px solid transparent;
-	border-top-left-radius: 10px;
-	border-bottom-left-radius: 10px;
+	border-top-left-radius: var(--brad);
+	border-bottom-left-radius: var(--brad);
 }
 
 tbody td:last-of-type {
 	border: 1px solid transparent;
-	border-top-right-radius: 10px;
-	border-bottom-right-radius: 10px;
+	border-top-right-radius: var(--brad);
+	border-bottom-right-radius: var(--brad);
 }
 
 /* grow run page */

--- a/app/src/lib/styles/global.css
+++ b/app/src/lib/styles/global.css
@@ -39,6 +39,14 @@ h4 {
 	@apply mb-2;
 }
 
+a {
+	@apply inline-block;
+}
+
+button {
+	@apply cursor-pointer;
+}
+
 button,
 nav a,
 nav p,
@@ -54,6 +62,10 @@ nav p,
 	@apply button-hover-effects transition-all  text-black;
 }
 
+.nav-item {
+	cursor: default;
+}
+
 .button-hover-effects:hover,
 .button-hover-effects:focus {
 	@apply bg-green-400 scale-110;
@@ -63,11 +75,14 @@ button * {
 	@apply text-black;
 }
 
-button .iconify {
-	@apply transition-all;
+button .iconify,
+a .iconify,
+.nav-item .iconify {
+	@apply scale-125 transition-all;
 }
 
-button:hover .iconify {
+button:hover .iconify,
+a:hover .iconify {
 	@apply rotate-[8deg] transition-all;
 }
 
@@ -144,8 +159,4 @@ tbody td:last-of-type {
 
 .grow-run-page > section {
 	@apply p-8 w-full;
-}
-
-.iconify {
-	@apply text-xl;
 }

--- a/app/src/routes/(app)/(authenticated)/grow-setups/+page.svelte
+++ b/app/src/routes/(app)/(authenticated)/grow-setups/+page.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import GrowSetupsActions from '$features/grow-setups/Actions.svelte';
+	import GrowSetups from '$features/grow-setups/View.svelte';
+</script>
+
+<main>
+	<div class="flex items-center justify-between">
+		<h1>Grow Setups</h1>
+		<GrowSetupsActions />
+	</div>
+	<GrowSetups />
+</main>

--- a/app/src/routes/(app)/(authenticated)/grow-setups/[id]/+page.svelte
+++ b/app/src/routes/(app)/(authenticated)/grow-setups/[id]/+page.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { page } from '$app/state';
+	import View from '$features/grow-setups/grow-setup/View.svelte';
+	import { growSetups } from '$features/grow-setups/store';
+
+	$: growSetup = $growSetups.find((growSetup) => growSetup.id === page.params.id);
+</script>
+
+<main>
+	{#if growSetup}
+		<View {growSetup} />
+	{/if}
+</main>

--- a/app/src/routes/(app)/+layout.svelte
+++ b/app/src/routes/(app)/+layout.svelte
@@ -11,8 +11,8 @@
 	import Loading from '$lib/components/Loading.svelte';
 	import { growRuns, growRunsLoading } from '$features/grow-runs/grow-run/store';
 	import { resourcesList, resourcesLoading } from '$features/resources/store';
-	import Icon from '@iconify/svelte';
 	import { auth } from '$features/user/auth';
+	import AuthMenu from '$lib/components/AuthMenu.svelte';
 
 	$: if (browser) initializeFirebase();
 
@@ -49,15 +49,8 @@
 			class="flex justify-between flex-wrap bg-gray-800 items-center p-4 text-white relative z-10"
 		>
 			<Menu />
-			<div class="flex gap-[15px] items-center">
-				<p class="hidden md:block">
-					Logged in: <span class="font-bold">{$session.user.email}</span>
-				</p>
-				<a class="nav-item" href="/settings">
-					<Icon icon="tabler:settings" />
-				</a>
-				<a class="nav-item" href="/logout">Logout</a>
-			</div>
+
+			<AuthMenu />
 		</div>
 	{/if}
 	<slot />

--- a/app/src/routes/welcome/+page.svelte
+++ b/app/src/routes/welcome/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import '$lib/styles/global.css';
-	import { PUBLIC_API_URL } from '$env/static/public';
+	import { API_URL } from '$env/static/public';
 	import Icon from '@iconify/svelte';
 
 	import {
@@ -22,7 +22,7 @@
 	async function requestASignUp(event: SubmitEvent) {
 		event.preventDefault();
 
-		const res = await fetch(`${PUBLIC_API_URL}/sign-up-request`, {
+		const res = await fetch(`${API_URL}/sign-up-request`, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({ 'user-email': emailAddressInput?.value })

--- a/app/svelte.config.js
+++ b/app/svelte.config.js
@@ -10,7 +10,7 @@ const config = {
 	kit: {
 		env: {
 			publicPrefix: '',
-			privatePrefix: 'SECRET'
+			privatePrefix: 'SECRET_'
 		},
 		alias: {
 			$features: 'src/features'

--- a/app/svelte.config.js
+++ b/app/svelte.config.js
@@ -8,6 +8,10 @@ const config = {
 	preprocess: vitePreprocess(),
 
 	kit: {
+		env: {
+			publicPrefix: '',
+			privatePrefix: 'SECRET'
+		},
 		alias: {
 			$features: 'src/features'
 		},

--- a/e2e-tests/.env.example
+++ b/e2e-tests/.env.example
@@ -1,2 +1,2 @@
-PUBLIC_UI_URL=https://localhost:5173
-CYPRESS_baseUrl=${PUBLIC_UI_URL}
+UI_URL=https://localhost:5173
+CYPRESS_baseUrl=${UI_URL}

--- a/e2e-tests/cypress/e2e/minimiseRegression/actions/growRunActions.ts
+++ b/e2e-tests/cypress/e2e/minimiseRegression/actions/growRunActions.ts
@@ -140,11 +140,11 @@ export class GrowRunManager implements EntityManager {
 			this.actionsMenu.open();
 			cy.findByTitle(growRunActionNames.start).click();
 			cy.findByRole('button', { name: /yes/i }).click();
-			this.checkStartTimeCorrect(dayjs(win.Date()));
+			this.testStartTimeCorrect(dayjs(win.Date()));
 		});
 	}
 
-	checkStartTimeCorrect(expectedStartTime: dayjs.Dayjs) {
+	testStartTimeCorrect(expectedStartTime: dayjs.Dayjs) {
 		cy.reload();
 		this.heroSection
 			.findByText('Started:', { exact: false })
@@ -192,7 +192,7 @@ export class GrowRunManager implements EntityManager {
 		this.actionsMenu.close();
 	}
 
-	checkLocationIsSet(location: undefined | ExpectedLocationDescription) {
+	testLocationIsSet(location: undefined | ExpectedLocationDescription) {
 		growRunsManager.goToAll();
 
 		if (!location) {
@@ -280,11 +280,11 @@ export class GrowRunManager implements EntityManager {
 			this.actionsMenu.open();
 			cy.findByTitle(growRunActionNames.end).click();
 			cy.findByRole('button', { name: /yes/i }).click();
-			this.checkEndTimeCorrect(dayjs(win.Date()));
+			this.testEndTimeCorrect(dayjs(win.Date()));
 		});
 	}
 
-	checkEndTimeCorrect(expectedEndTime: dayjs.Dayjs) {
+	testEndTimeCorrect(expectedEndTime: dayjs.Dayjs) {
 		cy.reload();
 		this.heroSection
 			.findByText('Ended:', { exact: false })

--- a/e2e-tests/cypress/e2e/minimiseRegression/actions/growRunActions.ts
+++ b/e2e-tests/cypress/e2e/minimiseRegression/actions/growRunActions.ts
@@ -4,7 +4,6 @@ import {
 	GrowRun,
 	growRunActionNames,
 	Harvest,
-	Location,
 	ResourceUsage
 } from '@grow-run-archive/definitions';
 

--- a/e2e-tests/cypress/e2e/minimiseRegression/actions/growRunActions.ts
+++ b/e2e-tests/cypress/e2e/minimiseRegression/actions/growRunActions.ts
@@ -42,7 +42,7 @@ class GrowRunsManager extends EntitiesManager {
 			if (index === 0) return;
 			cy.wrap($entity).findByRole('link').click();
 			// needs to navigate to record page
-			cy.url().should('not.equal', `${Cypress.env('PUBLIC_UI_URL')}${this.URL}`);
+			cy.url().should('not.equal', `${Cypress.env('UI_URL')}${this.URL}`);
 			this.deleteSingle();
 		});
 	}

--- a/e2e-tests/cypress/e2e/minimiseRegression/actions/growRunEnvironmentActions.ts
+++ b/e2e-tests/cypress/e2e/minimiseRegression/actions/growRunEnvironmentActions.ts
@@ -34,7 +34,7 @@ export class GrowRunEnvironmentManager {
 		cy.url().then(async (url) => {
 			const growRunId = url.split(growRunsManager.URL + '/')[1];
 			expect(growRunId).to.be.a('string').with.length.greaterThan(6);
-			const response = await fetch(`${Cypress.env('PUBLIC_API_URL')}/grow-run/environment`, {
+			const response = await fetch(`${Cypress.env('API_URL')}/grow-run/environment`, {
 				method: 'post',
 				body: JSON.stringify({
 					user: {

--- a/e2e-tests/cypress/e2e/minimiseRegression/actions/growSetupActions.ts
+++ b/e2e-tests/cypress/e2e/minimiseRegression/actions/growSetupActions.ts
@@ -1,0 +1,45 @@
+import {
+	growSetupActionNames,
+	GrowSetupType,
+	ExternalResource as Resource,
+	resourceActionNames
+} from '@grow-run-archive/definitions';
+import { EntitiesManager, EntityManager } from '../entity/manager';
+import { actionsMenu } from '../entity/actions';
+
+class GrowSetupsManager extends EntitiesManager {
+	constructor() {
+		super({ name: 'Grow Setup' });
+		this.actionNames = resourceActionNames;
+	}
+}
+
+export const growSetupsManager = new GrowSetupsManager();
+
+export class GrowSetupManager implements EntityManager {
+	growSetupVersion: GrowSetupType['version'];
+
+	constructor(growSetupVersion: GrowSetupType['version'], existingResource = false) {
+		this.growSetupVersion = growSetupVersion;
+		growSetupsManager.goToAll();
+		if (!existingResource) this.add();
+	}
+
+	get preview() {
+		return cy.contains('tr', this.growSetupVersion);
+	}
+
+	add() {
+		actionsMenu.open();
+		cy.findByTitle(growSetupActionNames.add).click();
+		actionsMenu.close();
+	}
+
+	goTo() {
+		this.preview.click();
+	}
+
+	showAllDetails = this.goTo;
+
+	delete = growSetupsManager.deleteSingle;
+}

--- a/e2e-tests/cypress/e2e/minimiseRegression/actions/userActions.ts
+++ b/e2e-tests/cypress/e2e/minimiseRegression/actions/userActions.ts
@@ -31,19 +31,19 @@ export class User {
 		this.testIsLoggedIn();
 	}
 
-	login(checkLoggedIn = true) {
+	login(testLoggedIn = true) {
 		this.logout();
 		cy.visit('/login');
 		cy.findByLabelText(/username/i).type(this.credentials.username);
 		cy.findByLabelText(/password/i).type(this.credentials.password);
 		cy.findByRole('button', { name: userActionNames.login }).click();
-		if (checkLoggedIn) this.testIsLoggedIn();
+		if (testLoggedIn) this.testIsLoggedIn();
 	}
 
 	testIsLoggedIn() {
 		cy.findByTitle(userActionNames.openMenu).realHover();
 		cy.get('nav').contains(`Logged in as ${this.credentials.username}`).should('be.visible');
-		cy.reload();
+		cy.get('body').realHover({ position: 'topLeft' });
 	}
 
 	deleteUser() {

--- a/e2e-tests/cypress/e2e/minimiseRegression/actions/userActions.ts
+++ b/e2e-tests/cypress/e2e/minimiseRegression/actions/userActions.ts
@@ -28,7 +28,7 @@ export class User {
 		cy.findByLabelText('Password').type(this.credentials.password);
 		cy.findByLabelText('Confirm Password').type(this.credentials.password);
 		cy.findByRole('button', { name: userActionNames.signup }).click();
-		this.isLoggedIn();
+		this.testIsLoggedIn();
 	}
 
 	login(checkLoggedIn = true) {
@@ -37,12 +37,13 @@ export class User {
 		cy.findByLabelText(/username/i).type(this.credentials.username);
 		cy.findByLabelText(/password/i).type(this.credentials.password);
 		cy.findByRole('button', { name: userActionNames.login }).click();
-		if (checkLoggedIn) this.isLoggedIn();
+		if (checkLoggedIn) this.testIsLoggedIn();
 	}
 
-	isLoggedIn() {
-		cy.findByText(`Logged in:`).should('be.visible');
-		cy.findByText(this.credentials.username).should('be.visible');
+	testIsLoggedIn() {
+		cy.findByTitle(userActionNames.openMenu).realHover();
+		cy.get('nav').contains(`Logged in as ${this.credentials.username}`).should('be.visible');
+		cy.reload();
 	}
 
 	deleteUser() {
@@ -50,13 +51,13 @@ export class User {
 		actionsMenu.open();
 		const deleteUserAction = userActionNames.deleteUser(this.credentials.username);
 		cy.findByRole('button', { name: deleteUserAction }).click();
-		cy.findParentByHeading('dialog', deleteUserAction)
+		const deleteActionModal = () => cy.findParentByHeading('dialog', deleteUserAction);
+
+		deleteActionModal()
 			.find('#confirm-delete-action')
 			.type(`delete ${this.credentials.username} password ${this.credentials.password}`);
 
-		cy.findParentByHeading('dialog', deleteUserAction)
-			.findByRole('button', { name: deleteUserAction })
-			.click();
+		deleteActionModal().findByRole('button', { name: deleteUserAction }).click();
 
 		cy.url().should('include', '/welcome');
 		this.testUserDeleted();
@@ -65,6 +66,6 @@ export class User {
 	testUserDeleted() {
 		this.logout();
 		this.login(false);
-		cy.findByText(`Logged in:`).should('not.exist');
+		cy.findByText(`Logged in`).should('not.exist');
 	}
 }

--- a/e2e-tests/cypress/e2e/minimiseRegression/entity/actions.ts
+++ b/e2e-tests/cypress/e2e/minimiseRegression/entity/actions.ts
@@ -17,7 +17,7 @@ export class ActionModal {
 	];
 
 	open() {
-		this.checkModalIsClosed();
+		this.testModalIsClosed();
 		cy.findByTitle(this.name, { exact: false }).should('be.visible');
 		randomlySample(this.openMethods)();
 		this.get().should('be.visible');
@@ -27,10 +27,10 @@ export class ActionModal {
 	close() {
 		this.get().should('be.visible');
 		randomlySample(this.closeMethods)();
-		this.checkModalIsClosed();
+		this.testModalIsClosed();
 	}
 
-	checkModalIsClosed() {
+	testModalIsClosed() {
 		cy.findByRole('heading', { name: this.modalHeading }).should('not.exist');
 	}
 

--- a/e2e-tests/cypress/e2e/minimiseRegression/index.cy.ts
+++ b/e2e-tests/cypress/e2e/minimiseRegression/index.cy.ts
@@ -67,11 +67,14 @@ describe('Grow Run Archive', () => {
 		};
 		growRun.addLocation('with coords', growRunCoords);
 		growRun.testLocationIsSet({
-			...growRunCoords,
-			suburb: 'Newmarket',
-			city: 'Auckland',
-			country: 'New Zealand'
+			coords: growRunCoords,
+			address: {
+				suburb: 'Newmarket',
+				city: 'Auckland',
+				country: 'New Zealand'
+			}
 		});
+
 		growRunsManager.goToAll();
 		growRun.showAllDetails();
 

--- a/e2e-tests/cypress/e2e/minimiseRegression/index.cy.ts
+++ b/e2e-tests/cypress/e2e/minimiseRegression/index.cy.ts
@@ -66,7 +66,7 @@ describe('Grow Run Archive', () => {
 			longitude: 174.77844419626646
 		};
 		growRun.addLocation('with coords', growRunCoords);
-		growRun.checkLocationIsSet({
+		growRun.testLocationIsSet({
 			...growRunCoords,
 			suburb: 'Newmarket',
 			city: 'Auckland',
@@ -74,14 +74,6 @@ describe('Grow Run Archive', () => {
 		});
 		growRunsManager.goToAll();
 		growRun.showAllDetails();
-
-		// DOESN"T WORK ON CHROME, WORKS ON EDGE
-		// cy.origin('https://www.google.com', () => {
-		// 	cy.url().should(
-		// 		'include',
-		// 		`https://www.google.com/maps/place/36%C2%B051'58.0%22S+174%C2%B045'57.2%22E/@-36.8661194,174.7658978,17z`
-		// 	);
-		// });
 
 		growRun.manuallyRecordUsageOfResources(resourceUsage1);
 

--- a/e2e-tests/cypress/support/commands.ts
+++ b/e2e-tests/cypress/support/commands.ts
@@ -24,11 +24,7 @@ declare global {
 
 import '@testing-library/cypress/add-commands';
 
-Cypress.Commands.add('recursionLoop', function (fn, times) {
-	if (typeof times === 'undefined') {
-		times = 0;
-	}
-
+Cypress.Commands.add('recursionLoop', function (fn, times = 0) {
 	cy.then(async () => {
 		const result = await fn(++times);
 		if (result !== false) {

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -3,8 +3,8 @@
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
-		"dev": "set 'CYPRESS_baseUrl=PUBLIC_UI_URL'&&; cypress open",
-		"local": "set 'CYPRESS_baseUrl=PUBLIC_UI_URL'&&; cypress run",
+		"dev": "set 'CYPRESS_baseUrl=UI_URL'&&; cypress open",
+		"local": "set 'CYPRESS_baseUrl=UI_URL'&&; cypress run",
 		"pipeline": "cypress run"
 	},
 	"type": "module",

--- a/jobs/src/cronJobs.ts
+++ b/jobs/src/cronJobs.ts
@@ -14,7 +14,7 @@ class MissingEnvironmentNotificationsCronJobLocal
 	implements MissingEnvironmentNotificationsCronJob
 {
 	start() {
-		if (!(process.env.PUBLIC_API_URL as string).includes('localhost')) return;
+		if (!(process.env.API_URL as string).includes('localhost')) return;
 		let loading = false;
 
 		const job = async () => {
@@ -28,8 +28,7 @@ class MissingEnvironmentNotificationsCronJobLocal
 				console.log('REQUESTING MISSING ENVIRONMENT NOTIFICATION ENDPOINT');
 				setTimeout(() => (loading = false), 15000);
 
-				const status = (await fetch(`${process.env.PUBLIC_API_URL}/notify-if-missing-environment`))
-					.status;
+				const status = (await fetch(`${process.env.API_URL}/notify-if-missing-environment`)).status;
 				if (status !== 200) {
 					setTimeout(() => (loading = false), 5000);
 					throw Error('Cron-Job failed with status ' + status);
@@ -70,9 +69,9 @@ class MissingEnvironmentNotificationsCronJobDeployed
 console.log('Cron jobs time');
 
 async function createMissingEnvironmentNotificationsCronJob() {
-	if (!process.env.PUBLIC_API_URL) throw Error('PUBLIC_API_URL not defined');
+	if (!process.env.API_URL) throw Error('API_URL not defined');
 
-	return process.env.PUBLIC_API_URL.includes('localhost')
+	return process.env.API_URL.includes('localhost')
 		? new MissingEnvironmentNotificationsCronJobLocal()
 		: new MissingEnvironmentNotificationsCronJobDeployed();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12691,11 +12691,21 @@
 		"packages/definitions": {
 			"name": "@grow-run-archive/definitions",
 			"dependencies": {
-				"@grow-run-archive/dayjs": "*"
+				"@grow-run-archive/dayjs": "*",
+				"zod": "^4.0.5"
 			},
 			"devDependencies": {
 				"@tsconfig/node-lts": "^22.0.1",
 				"typescript": "^5.8.3"
+			}
+		},
+		"packages/definitions/node_modules/zod": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
+			"integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"packages/environment": {

--- a/packages/definitions/package.json
+++ b/packages/definitions/package.json
@@ -16,6 +16,7 @@
         "typescript": "^5.8.3"
     },
     "dependencies": {
-        "@grow-run-archive/dayjs": "*"
+        "@grow-run-archive/dayjs": "*",
+        "zod": "^4.0.5"
     }
 }

--- a/packages/definitions/src/entity/actions.ts
+++ b/packages/definitions/src/entity/actions.ts
@@ -5,6 +5,10 @@ export class ActionNames {
 		this.entityName = entityName;
 	}
 
+	get openActions() {
+		return `Actions for ${this.entityName}s`;
+	}
+
 	get add() {
 		return `Add ${this.entityName}`;
 	}

--- a/packages/definitions/src/growRun/index.ts
+++ b/packages/definitions/src/growRun/index.ts
@@ -6,11 +6,13 @@ import { ResourceUsage } from './resourceUsage.js';
 import { Location } from './location.js';
 import dayjs from '@grow-run-archive/dayjs';
 import { Resource } from '../resource.js';
+import { GrowSetupType } from '../growSetup/index.js';
 
 export type GrowRunType = {
 	id: string;
 	name: string;
 	location?: Location;
+	growSetup?: GrowSetupType['id'];
 	duration?: Duration;
 
 	resources: { used?: ResourceUsage[]; required?: ResourceUsage[] };
@@ -23,12 +25,22 @@ export class GrowRun {
 	name: GrowRunType['name'];
 	duration: GrowRunType['duration'];
 	location: GrowRunType['location'];
+	growSetup: GrowRunType['growSetup'];
 
 	resources: Required<GrowRunType>['resources'];
 	harvests: Required<GrowRunType>['harvests'];
 	conditions: Required<GrowRunType>['conditions'];
 
-	constructor({ id, name, resources, harvests, conditions, duration, location }: GrowRunType) {
+	constructor({
+		id,
+		name,
+		resources,
+		harvests,
+		conditions,
+		duration,
+		location,
+		growSetup
+	}: GrowRunType) {
 		this.id = id;
 		this.name = name;
 		this.resources = resources || { used: [], required: [] };
@@ -36,6 +48,7 @@ export class GrowRun {
 		this.conditions = conditions || {};
 		this.duration = duration || {};
 		this.location = location;
+		this.growSetup = growSetup;
 	}
 
 	/**
@@ -135,6 +148,7 @@ class GrowRunActionNames extends ActionNames {
 	export = `Export Grow Run`;
 	rename = 'Rename Grow Run';
 	changeLocation = 'Change Grow Run Location';
+	changeGrowSetup = 'Change Grow Setup';
 	manageImages = 'Upload new or remove existing images';
 
 	// sub-entities

--- a/packages/definitions/src/growSetup/index.ts
+++ b/packages/definitions/src/growSetup/index.ts
@@ -27,6 +27,10 @@ export class GrowSetup {
 		this.link = link;
 	}
 
+	static sort(growSetups: GrowSetup[]) {
+		return growSetups.sort((a, b) => a.version.localeCompare(b.version));
+	}
+
 	get name(): string {
 		if (!this.nickname) return `Grow Setup #${this.version}`;
 		return `Grow Setup #${this.version} - ${this.nickname}`;

--- a/packages/definitions/src/growSetup/index.ts
+++ b/packages/definitions/src/growSetup/index.ts
@@ -1,0 +1,49 @@
+import z from 'zod/v4';
+import { ActionNames } from '../entity/actions.js';
+
+const versionRegex = /^(\d+\.)?(\d+\.)?(\*|\d+)$/;
+
+const GrowSetupSchema = z.object({
+	id: z.string(),
+	// should match 'number.number.number' ....
+	version: z.string().regex(versionRegex),
+	nickname: z.string().optional(),
+	link: z.url().optional()
+});
+
+export type GrowSetupType = z.infer<typeof GrowSetupSchema>;
+
+export class GrowSetup {
+	id: GrowSetupType['id'];
+	version: GrowSetupType['version'];
+	nickname: GrowSetupType['nickname'];
+	link: GrowSetupType['link'];
+
+	constructor(growSetupData: GrowSetupType) {
+		const { id, version, link, nickname } = GrowSetupSchema.parse(growSetupData);
+		this.id = id;
+		this.version = version;
+		this.nickname = nickname;
+		this.link = link;
+	}
+
+	get name(): string {
+		if (!this.nickname) return `Grow Setup #${this.version}`;
+		return `Grow Setup #${this.version} - ${this.nickname}`;
+	}
+
+	/** name but without the nickname */
+	get shortName() {
+		return this.name.split('-')[0];
+	}
+}
+
+class GrowSetupActionNames extends ActionNames {
+	constructor() {
+		super('Grow Setup');
+	}
+
+	rename = 'Rename Grow Run';
+}
+
+export const growSetupActionNames = new GrowSetupActionNames();

--- a/packages/definitions/src/growSetup/index.ts
+++ b/packages/definitions/src/growSetup/index.ts
@@ -42,8 +42,6 @@ class GrowSetupActionNames extends ActionNames {
 	constructor() {
 		super('Grow Setup');
 	}
-
-	rename = 'Rename Grow Run';
 }
 
 export const growSetupActionNames = new GrowSetupActionNames();

--- a/packages/definitions/src/index.ts
+++ b/packages/definitions/src/index.ts
@@ -1,4 +1,5 @@
 export * from './user/index.js';
+export * from './growSetup/index.js';
 export * from './growRun/index.js';
 export * from './growRun/resourceUsage.js';
 export * from './growRun/harvest.js';

--- a/packages/definitions/src/user/actions.ts
+++ b/packages/definitions/src/user/actions.ts
@@ -1,5 +1,6 @@
 class UserActionNames {
 	logout = (username: string) => `Logout ${username}`;
+	openMenu = 'User menu';
 	login = 'Login';
 	signup = 'Sign-up';
 	changePassword = `Change password`;


### PR DESCRIPTION
## Problem
#25 

## Solution

https://github.com/user-attachments/assets/4bed4e83-2080-4ecb-8ede-0e1fdb4f6610

* Storing grow setup separate!
* it can be searched
* it can open confluence link


## Code changes
* added pages and actions for grow setups
* relating grow runs to a grow setup
* added firebase emulator for low risk local development (potential solution for #28) 
* ☝️ resulted in simpler ENV variables names (no PUBLIC_ prefix) so I have to updated all environments
* cleaned up auth menu into a menu dropdown



